### PR TITLE
feat: add PI classification engine

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -13,6 +13,8 @@ class Settings(BaseSettings):
     redis_max_connections: int = 20
     redis_timeout: int = 5
     classification_ttl: int = 60 * 60 * 24  # 24 hours
+    model_name: str = "hf-internal-testing/tiny-bert-for-token-classification"
+    confidence_threshold: float = 0.85
 
     class Config:
         env_file = ".env"

--- a/app/pii_classifier.py
+++ b/app/pii_classifier.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Optional
+import re
+
+from transformers import pipeline
+
+
+@dataclass
+class PIIDetection:
+    """Dataclass representing a single PI detection result."""
+    pii_type: str
+    value: str
+    score: float
+    start: int
+    end: int
+
+
+class PIIClassifier:
+    """Basic PI classifier using regex patterns and a HuggingFace token classifier.
+
+    The model is loaded lazily on first use to keep import times fast. Regex based
+    detectors cover common structured PI such as email addresses or phone numbers
+    while the BERT model is used for free-form entities like names and locations.
+    """
+
+    def __init__(
+        self,
+        model_name: str = "hf-internal-testing/tiny-bert-for-token-classification",
+        confidence_threshold: float = 0.85,
+        device: int = -1,
+    ) -> None:
+        self.model_name = model_name
+        self.confidence_threshold = confidence_threshold
+        self.device = device
+        self._nlp: Optional[callable] = None
+
+        # Regex patterns for structured PI
+        self.email_re = re.compile(r"[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}")
+        self.phone_re = re.compile(r"(?:\+?\d{1,2}[\s-]?)?\(?\d{3}\)?[\s-]?\d{3}[\s-]?\d{4}")
+        self.ssn_re = re.compile(r"\b\d{3}-\d{2}-\d{4}\b")
+        self.cc_re = re.compile(r"(?:\d[ -]*?){13,16}")
+        self.ip_re = re.compile(
+            r"\b(?:\d{1,3}\.){3}\d{1,3}\b"  # IPv4 simplified
+            r"|\b(?:[A-Fa-f0-9:]+:+)+[A-Fa-f0-9]+\b"  # IPv6
+        )
+        self.url_re = re.compile(r"https?://[\w./-]+")
+        self.dob_re = re.compile(r"\b\d{1,2}[/-]\d{1,2}[/-]\d{2,4}\b")
+        self.govid_re = re.compile(r"\b[A-Z0-9]{8,}\b")
+
+    # ------------------------- Utility methods -------------------------
+    def _load_model(self) -> None:
+        if self._nlp is None:
+            try:
+                self._nlp = pipeline(
+                    "token-classification",
+                    model=self.model_name,
+                    aggregation_strategy="simple",
+                    device=self.device,
+                )
+            except Exception:
+                # In environments without the model or transformers installed we
+                # simply keep _nlp as None. Regex based detectors will still work.
+                self._nlp = None
+
+    @staticmethod
+    def _luhn_check(number: str) -> bool:
+        digits = [int(ch) for ch in number if ch.isdigit()]
+        checksum = 0
+        parity = len(digits) % 2
+        for i, d in enumerate(digits):
+            if i % 2 == parity:
+                d *= 2
+                if d > 9:
+                    d -= 9
+            checksum += d
+        return checksum % 10 == 0
+
+    # ---------------------------- Detectors ----------------------------
+    def _regex_detect(self, text: str) -> List[PIIDetection]:
+        res: List[PIIDetection] = []
+
+        for m in self.email_re.finditer(text):
+            res.append(PIIDetection("EMAIL", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.phone_re.finditer(text):
+            res.append(PIIDetection("PHONE", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.ssn_re.finditer(text):
+            res.append(PIIDetection("SSN", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.cc_re.finditer(text):
+            cc = m.group().replace(" ", "").replace("-", "")
+            if 13 <= len(cc) <= 16 and self._luhn_check(cc):
+                res.append(PIIDetection("CREDIT_CARD", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.ip_re.finditer(text):
+            res.append(PIIDetection("IP_ADDRESS", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.url_re.finditer(text):
+            res.append(PIIDetection("URL", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.dob_re.finditer(text):
+            res.append(PIIDetection("DATE_OF_BIRTH", m.group(), 1.0, m.start(), m.end()))
+
+        for m in self.govid_re.finditer(text):
+            res.append(PIIDetection("GOV_ID", m.group(), 1.0, m.start(), m.end()))
+
+        return res
+
+    def _ner_detect(self, text: str) -> List[PIIDetection]:
+        self._load_model()
+        res: List[PIIDetection] = []
+        if self._nlp is None:
+            return res
+        for ent in self._nlp(text):
+            label = ent.get("entity_group")
+            if label == "PER":
+                pii_type = "NAME"
+            elif label == "LOC":
+                pii_type = "ADDRESS"
+            else:
+                continue
+            res.append(
+                PIIDetection(
+                    pii_type,
+                    ent["word"],
+                    float(ent["score"]),
+                    int(ent["start"]),
+                    int(ent["end"]),
+                )
+            )
+        return res
+
+    # ---------------------------- Public API ----------------------------
+    def classify_text(self, text: str, threshold: Optional[float] = None) -> List[PIIDetection]:
+        threshold = self.confidence_threshold if threshold is None else threshold
+        results = self._regex_detect(text)
+        results.extend(self._ner_detect(text))
+        return [r for r in results if r.score >= threshold]
+
+    def classify_batch(self, texts: List[str], threshold: Optional[float] = None) -> List[List[PIIDetection]]:
+        return [self.classify_text(t, threshold) for t in texts]

--- a/readme.md
+++ b/readme.md
@@ -50,3 +50,25 @@ On startup the tables defined in `app/models.py` will be created automatically.
 ```bash
 pytest
 ```
+
+## PI Classification Engine
+
+The API gateway bundles a lightweight personal information (PI) classifier. It
+uses regular expressions for structured entities (email, phone, SSN, credit
+card, IP addresses, URLs, dates and generic government IDs) and a tiny
+HuggingFace BERT model for free‑form entities like names or locations. The
+model is loaded lazily on first use and falls back to the regex detectors if the
+model cannot be loaded.
+
+Example usage from Python:
+
+```python
+from app.pii_classifier import PIIClassifier
+
+clf = PIIClassifier()
+print(clf.classify_text("Email me at user@example.com"))
+```
+
+The `/api/v1/classify/text` endpoint accepts a JSON body `{"text": "..."}` and
+returns a list of detected entities with confidence scores. Batch processing is
+available via `/api/v1/classify/batch`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ asyncpg
 alembic
 redis>=4.5
 fakeredis>=2.21
+transformers

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,7 +2,7 @@ import pytest
 import fakeredis
 
 from app import cache
-from app.main import fake_classify
+from app.main import classify_pii
 
 @pytest.mark.asyncio
 async def test_cache_set_get(monkeypatch):
@@ -16,12 +16,12 @@ async def test_cache_set_get(monkeypatch):
     assert ttl > 0
 
 @pytest.mark.asyncio
-async def test_fake_classify_uses_cache(monkeypatch):
+async def test_classify_uses_cache(monkeypatch):
     r = fakeredis.aioredis.FakeRedis()
     monkeypatch.setattr(cache, "redis_client", r)
     await r.flushdb()
-    res1 = await fake_classify("hi")
-    assert await r.exists(cache.text_key("classify", "hi")) == 1
-    res2 = await fake_classify("hi")
+    res1 = await classify_pii("Contact me at user@example.com")
+    assert await r.exists(cache.text_key("classify", "Contact me at user@example.com")) == 1
+    res2 = await classify_pii("Contact me at user@example.com")
     assert res1 == res2
 

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -1,0 +1,29 @@
+import pytest
+
+from app.pii_classifier import PIIClassifier
+
+
+def test_regex_detections():
+    clf = PIIClassifier()
+    text = (
+        "Email user@example.com phone 123-456-7890 "
+        "SSN 123-45-6789 card 4111 1111 1111 1111 "
+        "ip 192.168.0.1 site https://example.com"
+    )
+    res = clf.classify_text(text)
+    types = {r.pii_type for r in res}
+    assert {"EMAIL", "PHONE", "SSN", "CREDIT_CARD", "IP_ADDRESS", "URL"}.issubset(types)
+
+
+def test_batch_processing():
+    clf = PIIClassifier()
+    texts = ["user@example.com", "123-456-7890"]
+    res = clf.classify_batch(texts)
+    assert res[0][0].pii_type == "EMAIL"
+    assert res[1][0].pii_type == "PHONE"
+
+
+def test_threshold():
+    clf = PIIClassifier()
+    res = clf.classify_text("nothing here", threshold=0.99)
+    assert res == []


### PR DESCRIPTION
## Summary
- add regex + BERT-based classifier for personal information detection with lazy model loading
- expose PI detection results via `/api/v1/classify/*` endpoints and cache results
- document classifier usage and add tests covering detection

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688daec4be48832c9b323192b69bcdf9